### PR TITLE
added get Headers method for serice object

### DIFF
--- a/lib/service.gen.sync.js
+++ b/lib/service.gen.sync.js
@@ -46,6 +46,11 @@ internals.Service.prototype.setHeaders = function(headers) {
   this.fixedHeaders = headers;
 };
 
+// get headers that will stay in all requests
+internals.Service.prototype.getHeaders = function() {
+  return this.fixedHeaders;
+};
+
 // set extra session rules applied to all requests
 // params:
 // {


### PR DESCRIPTION
Client callers might want to append headers later in the workflow. We can only set headers only with setHeaders or we can only override the existing headers. There is no way to append new headers to existing ones.

Hence added get Headers method , this will return existing headers for the service object, client can choose to append new headers to the existing one with both getHeaders and setHeaders method.